### PR TITLE
Add root .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# DFINITY local build artifacts
+.dfx/
+
+# Node dependencies
+node_modules/
+
+# Build outputs
+/dist/
+/dist-ssr/
+/build/
+
+# Miscellaneous files
+*.log
+logs/
+.DS_Store
+.env
+.idea/


### PR DESCRIPTION
## Summary
- add `.gitignore` in repo root to ignore local build output and dependencies

## Testing
- `npm install` in `frontend`
- `npm run lint` *(fails: cannot find @typescript-eslint/no-explicit-any)*

------
https://chatgpt.com/codex/tasks/task_b_688411e881988333a751b4b5bb77af62